### PR TITLE
Make module agnostic of stockfish version

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -121,13 +121,7 @@ class Stockfish {
         : this.partialResponse;
     });
     // wait for welcome message
-    this.do(
-      null,
-      (response: string) =>
-        response.indexOf(
-          `Stockfish 11 64 POPCNT by T. Romstad, M. Costalba, J. Kiiski, G. Linscott`
-        ) > -1
-    );
+    this.do(null, (response: string) => response.indexOf(`Stockfish`) > -1);
     // set options
     this.setoptions(options);
     // although the contructor is sync, the next command will wait for everything to process


### PR DESCRIPTION
With this change, we only search for the `Stockfish` substring in the welcome message.

A `git blame` of the file in the official Stockfish repo where the welcome message is constructed shows that the `Stockfish` part hasn't changed in the last 8 years: https://github.com/official-stockfish/Stockfish/blame/master/src/misc.cpp#L152, so this fix should at least enable this module to work with stockfish versions compiled after that change